### PR TITLE
Fixed target component not updating when binding is empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ vueHighlightJS.install = function install(Vue) {
       for (var i = 0; i < targets.length; i += 1) {
         const target = targets[i];
 
-        if (binding.value) {
+        if (typeof binding.value === 'string') {
           // if a value is directly assigned to the directive, use this
           // instead of the element content.
           target.textContent = binding.value;
@@ -27,7 +27,7 @@ vueHighlightJS.install = function install(Vue) {
 
       for (var i = 0; i < targets.length; i += 1) {
         const target = targets[i];
-        if (binding.value) {
+        if (typeof binding.value === 'string') {
           target.textContent = binding.value;
           hljs.highlightBlock(target);
         }


### PR DESCRIPTION
How to reproduce: Bind a textarea value to a highlightBlock, type some text then delete it. The code block just cannot be cleared.

And `bind.value` should also be restricted to string, so I'm using `typeof` to fix.
