### PR TITLE
Add argument to specify needed languages

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,18 @@
 'use strict';
 
-var hljs = require('highlight.js');
-// import hljs from 'highlight.js';
-
+var hljs;
 var vueHighlightJS = {};
-vueHighlightJS.install = function install(Vue) {
+vueHighlightJS.install = function install(Vue, langs) {
+  if (langs && Array.isArray(langs)) {
+    // import hljs from 'highlight.js' and register only the needed languages.
+    hljs = require("highlight.js/lib/highlight.js");
+    for (var i = 0, len = langs.length; i < len; i++) {
+      hljs.registerLanguage(langs[i], require('highlight.js/lib/languages/' + langs[i]));
+    }
+  } else {
+    // import hljs from 'highlight.js' and register all languages.
+    hljs = require('highlight.js');
+  }
   Vue.directive('highlightjs', {
     deep: true,
     bind: function bind(el, binding) {


### PR DESCRIPTION
If we use vue-highlightjs with webpack, we get a huge bundle size, due to all the useless languages that imported by default in highlight.js's entry `highlight.js/lib/index.js`.

According to [this issue](https://github.com/isagalaev/highlight.js/issues/1257#issuecomment-254504876) of highlight.js, we can actually import only the languages that needed.