### PR TITLE
fixed bug where highlight does not occurr in code blocks in directive

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,8 @@ vueHighlightJS.install = function install(Vue) {
         target = targets[i];
         if (typeof binding.value === 'string') {
           target.textContent = binding.value;
-          hljs.highlightBlock(target);
         }
+        hljs.highlightBlock(target);
       }
     }
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -66,3 +66,32 @@ describe('highlighting dynamic code', () => {
     });
   });
 });
+
+
+describe('highlighting code within dynamic content', () => {
+  let vm, result;
+
+  beforeEach(() => {
+    const template = `
+      <div id="app">
+        <div v-html="sourcecode" v-highlightjs></div>
+      </div>
+    `;
+
+    vm = new Vue({
+      template,
+      data: {
+        sourcecode: '<h2>foo</h2><pre><code class="javascript"></code></pre>',
+      },
+    }).$mount();
+  });
+
+  it('should updated highlighted block when updating code without any content', () => {
+    vm.sourcecode = '<h2>bar</h2><pre><code class="javascript"></code></pre>';
+    Vue.nextTick(function () {
+      result = vm.$el.innerHTML;
+      // console.log('result', result);
+      expect(result).toEqual('<div><h2>bar</h2><pre><code class="javascript hljs"></code></pre></div>');
+    });
+  });
+});


### PR DESCRIPTION
a bit of an edge case, but highlightjs was not locating code blocks within content dynamically loading in to an element. 

for example, I was using a markdown parser to load html, then using v-highlightjs to highlight the code blocks within the markdown. on refresh of the markdown, v-highlightjs was failing to locate the new code blocks.