### PR TITLE
Update hljs API call

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ vueHighlightJS.install = function install(Vue) {
           target.textContent = binding.value;
         }
 
-        hljs.highlightBlock(target);
+        hljs.highlightElement(target);
       }
     },
     componentUpdated: function componentUpdated(el, binding) {
@@ -36,7 +36,7 @@ vueHighlightJS.install = function install(Vue) {
         if (typeof binding.value === 'string') {
           target.textContent = binding.value;
         }
-        hljs.highlightBlock(target);
+        hljs.highlightElement(target);
       }
     }
   });


### PR DESCRIPTION
Updated hljs API call from `highlightBlock` to `highlightElement` as this will be deprecated in hljs v12:

Console output
`Deprecated as of 10.7.0. Please use highlightElement now.`
`Deprecated as of 10.7.0. highlightBlock will be removed entirely in v12.0`
